### PR TITLE
chore(vercel): 404 page not displayed in production

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "github": {
     "silent": true
-  }
+  },
+  "cleanUrls": true
 }


### PR DESCRIPTION
Hi!

I have noticed that 404 page is not displayed in production when deployed to Vercel.  For example, https://uses.craftz.dog/invalid-slug just shows the index page.

Currently, they have some issues and according to Astro docs the fix is to add the following lines to `vercel.json`:
```json
{
  "cleanUrls": true,
}
```
You can refer to the docs [here](https://docs.astro.build/en/guides/deploy/vercel/#static-site).

Have a nice one and hope this helps! 